### PR TITLE
Pull Classification api tests

### DIFF
--- a/src/apitest.html
+++ b/src/apitest.html
@@ -9,11 +9,16 @@
 <html>
   <head>
     <title>LOC API Test</title>
+    <meta charset="utf-8">
   </head>
   <body>
     <p>Click the buttons below to test the API indicated:</p>
-    <button id="loc">Library of Congress</button>
-    <button id="oclc">OCLC Classify</button>
-    <script src="script/request.js"></script>
+    <div>
+      <label for="isbn">Enter ISBN or search term here:</label>
+      <input type="text" id="isbn">
+      <button id="loc">Library of Congress</button>
+      <button id="oclc">OCLC Classify</button>
+      <script src="script/request.js"></script>
+    </div>
   </body>
 </html>

--- a/src/apitest.html
+++ b/src/apitest.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<!--
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
+<html>
+  <head>
+    <title>LOC API Test</title>
+  </head>
+  <body>
+    <p>Click the buttons below to test the API indicated:</p>
+    <button id="loc">Library of Congress</button>
+    <button id="oclc">OCLC Classify</button>
+    <script src="script/request.js"></script>
+  </body>
+</html>

--- a/src/script/request.js
+++ b/src/script/request.js
@@ -1,0 +1,62 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Exploring the use of both API options for finding book classification.
+ * 
+ * Written by Isaac List in September 2021
+ */
+
+/**
+ * Library of Congress uses a JSON-supplying API, accessible 
+ * through a more contemporary requests setup
+ */
+async function requestinfo(url) {
+    return fetch(url)
+    .then(response => response.json())
+    .then(json => printData(json))
+    .catch(function() {
+        console.log("An error occurred");
+    });
+}
+
+function printData(data) {
+    console.log(data);
+}
+
+async function loc() {
+    let url = "https://www.loc.gov/item/ihas.200196396/?fo=json";
+
+    let information = await requestinfo(url);
+    console.log(information);
+}
+
+/**
+ * OCLC's "Classify2" uses a RESTful API supplying XML-formatted data
+ */
+function classify() {
+    const request = new XMLHttpRequest();
+    let baseURL = "http://classify.oclc.org/classify2/Classify?";
+
+    let url = baseURL + "isbn=0679442723&summary=true";
+
+    request.open("GET", url);
+    request.send();
+
+    request.onload = (e) => {
+        console.log(request.response);
+    }
+}
+
+function main() {
+    let locbutton = document.getElementById("loc");
+    locbutton.addEventListener("click", loc);
+
+    let oclcbutton = document.getElementById("oclc");
+    oclcbutton.addEventListener("click", classify);
+}
+
+main();

--- a/src/script/request.js
+++ b/src/script/request.js
@@ -17,18 +17,17 @@
 async function requestinfo(url) {
     return fetch(url)
     .then(response => response.json())
-    .then(json => printData(json))
     .catch(function() {
         console.log("An error occurred");
     });
 }
 
-function printData(data) {
-    console.log(data);
-}
-
 async function loc() {
-    let url = "https://www.loc.gov/item/ihas.200196396/?fo=json";
+    // Get search term provided by user
+    let searchbox = document.getElementById("isbn");
+    let term = searchbox.value;
+
+    let url = "https://www.loc.gov/search/?q=" + term + "&fo=json";
 
     let information = await requestinfo(url);
     console.log(information);
@@ -36,12 +35,21 @@ async function loc() {
 
 /**
  * OCLC's "Classify2" uses a RESTful API supplying XML-formatted data
+ * 
+ * Note that this code would have to be run on the
+ * back-end, due to CORS restrictions. Consider this
+ * an example of the URL parameter(s) and thus the
+ * information we would need from the user.
  */
 function classify() {
+    // Get ISBN provided by user
+    let searchbox = document.getElementById("isbn");
+    let isbn = searchbox.value;
+
     const request = new XMLHttpRequest();
     let baseURL = "http://classify.oclc.org/classify2/Classify?";
 
-    let url = baseURL + "isbn=0679442723&summary=true";
+    let url = baseURL + "isbn=" + isbn + "&summary=true";
 
     request.open("GET", url);
     request.send();
@@ -59,4 +67,4 @@ function main() {
     oclcbutton.addEventListener("click", classify);
 }
 
-main();
+window.onload = main;


### PR DESCRIPTION
These tests simply demonstrate the API's, we will create a separate branch for the actual implementaiton.

**Some notes:**
 - LOC's API search doesn't allow for search by ISBN, though it does have a direct item request via their own identifier
 - OCLC's API needs to be accessed from the back-end code, CORS disallows access from front-end
 - OCLC *does* allow for search by ISBN, which is better (in my opinion anyway)

**Conclusions:**
So long as parsing XML isn't a problem, OCLC's service is a step above the Library of Congress. I imagine we will have a search feature, allowing the user to select from a list of suggested titles; both LOC and OCLC allow for this, though LOC probably has more detailed information and search options. My preference would be to implement OCLC as the classifier, and possibly utilize LOC if we need more than just title/author search.
